### PR TITLE
Add ECE and Chem Eng department pages with study notes

### DIFF
--- a/dept_cheme.html
+++ b/dept_cheme.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BitHuB - Dept. of Chem Eng</title>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="stylesyllabus.css">
+</head>
+<body>
+    <header class="ihead">
+        <nav>
+            <div class="logo1"><img src="bit2.png" alt=""></div>
+            <div class="logo"><b class="bithub1">BitHuB</b></div>
+            <ul class="nav-links">
+                <li><a href="index.html">Home</a></li>                
+                <li><a href="syllabus.html">Syllabus</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <div class="syllabus0">
+        <div class="syllabus1">
+            <div class="syllabus11" style="font-size: 14px;"><b>Dept. of Chem Eng</b></div>
+            <div style="text-align: center; font-size: 12px; color: white; padding: 5px;">
+                Credits to: <a href="https://sites.google.com/bitmesra.ac.in/cheminosk21/home?authuser=0" target="_blank" style="color: #6b9cf7; text-decoration: none;">Cheminos Website</a>
+            </div>
+            
+            <!-- Sem III & IV (Year 2) -->
+            <a href="https://sites.google.com/bitmesra.ac.in/cheminosk21/year-2?authuser=0" target="_blank">
+                <div class="syllabus12 main1">SEM III & IV</div>
+            </a>
+            <!-- Sem V & VI (Year 3) -->
+            <a href="https://sites.google.com/bitmesra.ac.in/cheminosk21/year-3?authuser=0" target="_blank">
+                <div class="syllabus12 main1">SEM V & VI</div>
+            </a>
+        </div>
+    </div>
+</body>
+</html>

--- a/dept_ece.html
+++ b/dept_ece.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>BitHuB - Dept. ECE</title>
+    <link rel="stylesheet" href="styles.css">
+    <link rel="stylesheet" href="stylesyllabus.css">
+</head>
+<body>
+    <header class="ihead">
+        <nav>
+            <div class="logo1"><img src="bit2.png" alt=""></div>
+            <div class="logo"><b class="bithub1">BitHuB</b></div>
+            <ul class="nav-links">
+                <li><a href="index.html">Home</a></li>                
+                <li><a href="syllabus.html">Syllabus</a></li>
+            </ul>
+        </nav>
+    </header>
+
+    <div class="syllabus0">
+        <div class="syllabus1">
+            <div class="syllabus11"><b>ECE Department</b></div>
+            
+            <!-- Sem 5 & 6 Notes -->
+            <a href="https://drive.google.com/drive/folders/1aLX_kDu14Pts27lwQ7x__scY3y0NSQ4t" target="_blank">
+                <div class="syllabus12 main1">SEM V & VI</div>
+            </a>
+        </div>
+    </div>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -356,6 +356,13 @@
       <a href="nss.html"           class="course-card"><span class="course-name">NSS</span><span class="course-credits">1 Credit</span></a>
     </div>
 
+    <div class="crazy-divider" data-label="Departments"></div>
+
+    <div class="courses-grid">
+      <a href="dept_ece.html" class="course-card"><span class="course-name">Dept. ECE</span><span class="course-credits">Sem V & VI</span></a>
+      <a href="dept_cheme.html" class="course-card"><span class="course-name">Dept. of Chem Eng</span><span class="course-credits">Sem III - VI</span></a>
+    </div>
+
   </section>
   <!-- ── /Courses ─────────────────────────────────────────── -->
 


### PR DESCRIPTION
This update introduces a new Departments section to the homepage and adds two new pages: dept_ece.html and dept_cheme.html. The ECE page provides links to semester 5 and 6 notes. The Chem Eng page provides links to semester 3 through 6 notes and credits the Cheminos website. Navigation and formatting are consistent with the existing syllabus pages.